### PR TITLE
Get `npm test` working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - "7"
+notifications:
+  disabled: true

--- a/index.js
+++ b/index.js
@@ -14,9 +14,7 @@ module.exports = robot => {
                 creator: userLogin
             }));
 
-            const countPR = response.data.filter(function (data) {
-                if (data.pull_request) return data;
-            });
+            const countPR = response.data.filter(data => data.pull_request);
 
             if (countPR.length === 1) {
                 let config;
@@ -25,7 +23,9 @@ module.exports = robot => {
                     const res = await context.github.repos.getContent(options);
                     config = yaml.load(Buffer.from(res.data.content, 'base64').toString()) || {};
                 } catch (err) {
-                    if (err.code !== 404) throw err;
+                    if (err.code !== 404) {
+                        throw err;
+                    }
                 }
                 context.github.issues.createComment(context.issue({body: config.firstPRMergeComment}));
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -1118,7 +1117,7 @@
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.16.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
+        "js-yaml": "3.9.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.3.0",
@@ -1151,6 +1150,15 @@
             "path-is-absolute": "1.0.1"
           }
         }
+      }
+    },
+    "eslint-config-probot": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-probot/-/eslint-config-probot-0.1.0.tgz",
+      "integrity": "sha1-Mw+4aGy1O/G5yKOsIlRhxEANT6k=",
+      "dev": true,
+      "requires": {
+        "eslint-config-xo": "0.18.2"
       }
     },
     "eslint-config-xo": {
@@ -1313,10 +1321,9 @@
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "espurify": {
       "version": "1.7.0",
@@ -2450,13 +2457,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true,
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
+      "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
       "requires": {
         "argparse": "1.0.9",
-        "esprima": "3.1.3"
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -4061,8 +4067,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/behaviorbot/first-pr-merge#readme",
   "devDependencies": {
+    "eslint-config-probot": "^0.1.0",
     "expect": "^1.20.2",
     "localtunnel": "^1.8.3",
     "mocha": "^3.4.2",
@@ -26,5 +27,8 @@
   },
   "xo": {
     "space": 4
+  },
+  "dependencies": {
+    "js-yaml": "^3.9.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ describe('first-pr-merge', () => {
                 )),
                 createComment: expect.createSpy()
             }
-        };;
+        };
 
         robot.auth = () => Promise.resolve(github);
     });


### PR DESCRIPTION
This fixes `npm test` by:

- `npm install -save-dev eslint-config-probot`
- fix lint errors when running `npm test`
- Adding a `.travis.yml` so travis can be enabled for this repository (go to https://travis-ci.org/profile/behaviorbot to enable)

