### PR TITLE
Addresses deprecation in Octokit

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = app => {
     if (context.payload.pull_request.merged) {
       const creator = context.payload.pull_request.user.login
       const { owner, repo } = context.repo()
-      const res = await context.github.search.issues({ q: `is:pr is:merged author:${creator} repo:${owner}/${repo}` })
+      const res = await context.github.search.issuesAndPullRequests({ q: `is:pr is:merged author:${creator} repo:${owner}/${repo}` })
 
       const mergedPRs = res.data.items.filter(pr => pr.number !== context.payload.pull_request.number)
 

--- a/test/index.js
+++ b/test/index.js
@@ -24,12 +24,12 @@ describe('first-pr-merge', () => {
   describe('first-pr-merge success', () => {
     it('posts a comment because it is a user\'s first pr merged', async () => {
       expect.spyOn(github.repos, 'getContents').andReturn(makeResponse(`firstPRMergeComment: >\n  Hello World!`))
-      expect.spyOn(github.search, 'issues').andReturn(Promise.resolve({ data: { items: [] } }))
+      expect.spyOn(github.search, 'issuesAndPullRequests').andReturn(Promise.resolve({ data: { items: [] } }))
       expect.spyOn(github.issues, 'createComment')
 
       await app.receive(successPayload)
 
-      expect(github.search.issues).toHaveBeenCalledWith({
+      expect(github.search.issuesAndPullRequests).toHaveBeenCalledWith({
         q: `is:pr is:merged author:hiimbex-test repo:hiimbex/testing-things`
       })
 
@@ -46,12 +46,12 @@ describe('first-pr-merge', () => {
   describe('first-pr-merge failure', () => {
     it('posts a comment because it is a user\'s first pr merged', async () => {
       expect.spyOn(github.repos, 'getContents').andReturn(makeResponse(`firstPRMergeComment: >\n  Hello World!`))
-      expect.spyOn(github.search, 'issues').andReturn(Promise.resolve({ data: { items: ['hi', 'also hi'] } }))
+      expect.spyOn(github.search, 'issuesAndPullRequests').andReturn(Promise.resolve({ data: { items: ['hi', 'also hi'] } }))
       expect.spyOn(github.issues, 'createComment')
 
       await app.receive(failPayload)
 
-      expect(github.search.issues).toHaveBeenCalledWith({
+      expect(github.search.issuesAndPullRequests).toHaveBeenCalledWith({
         q: `is:pr is:merged author:hiimbex repo:hiimbex/testing-things`
       })
 


### PR DESCRIPTION
```
Deprecation: [@octokit/rest] octokit.search.issues() has been renamed to
octokit.search.issuesAndPullRequests() (2018-12-27)
```